### PR TITLE
Fix conversion issue when `GetTypes()` returns null

### DIFF
--- a/src/Dashboard/version.json
+++ b/src/Dashboard/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.2",
+  "version": "3.0.3",
   "pathFilters": ["."],
   "inherit": true
 }

--- a/src/WebAPI/Infrastructure/JsonTypeConverter.cs
+++ b/src/WebAPI/Infrastructure/JsonTypeConverter.cs
@@ -105,7 +105,7 @@ namespace Jobbr.Server.WebAPI.Infrastructure
             {
                 if (_possibleTypes == null)
                 {
-                    _possibleTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).Where(t => t.IsSubclassOf(typeof(TType)) || typeof(TType).IsAssignableFrom(t)).ToList();
+                    _possibleTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(GetLoadableTypes).Where(t => t.IsSubclassOf(typeof(TType)) || typeof(TType).IsAssignableFrom(t)).ToList();
                 }
             }
             catch (ReflectionTypeLoadException e)
@@ -121,6 +121,19 @@ namespace Jobbr.Server.WebAPI.Infrastructure
             }
 
             return _possibleTypes;
+        }
+
+        // See also: https://github.com/dotnet/SqlClient/issues/1930#issuecomment-2195775595
+        private static Type[] GetLoadableTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where((Func<Type, bool>)(t => t != null)).ToArray();
+            }
         }
 
         private Type GetTypeFromJsonProperty(JsonElement jsonObject)

--- a/src/WebAPI/version.json
+++ b/src/WebAPI/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.4",
+  "version": "3.0.5",
   "pathFilters": ["."],
   "inherit": true
 }


### PR DESCRIPTION
Fixes #38

Some (buggy) Assemblies can cause the dotnet runtime to throw an exception when trying to retrieve all types from an assembly through `GetTypes()`. The suggested workaround is to capture the exception and filter out the `null` types.

See also https://github.com/dotnet/SqlClient/issues/1930#issuecomment-2195775595