### PR TITLE
Mark Model dependency as private

### DIFF
--- a/src/Client/Jobbr.Client.csproj
+++ b/src/Client/Jobbr.Client.csproj
@@ -12,7 +12,9 @@
     <PackageIcon>images\icon.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\WebAPI.Model\Jobbr.Server.WebAPI.Model.csproj" />
+    <ProjectReference Include="..\WebAPI.Model\Jobbr.Server.WebAPI.Model.csproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146">

--- a/src/Client/version.json
+++ b/src/Client/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.4",
+  "version": "3.0.5",
   "pathFilters": ["."],
   "inherit": true
 }

--- a/src/WebAPI/Jobbr.Server.WebAPI.csproj
+++ b/src/WebAPI/Jobbr.Server.WebAPI.csproj
@@ -26,7 +26,9 @@
   <ItemGroup>
     <ProjectReference Include="..\ComponentModel\Management\Jobbr.ComponentModel.Management.csproj" />
     <ProjectReference Include="..\ComponentModel\Registration\Jobbr.ComponentModel.Registration.csproj" />
-    <ProjectReference Include="..\WebAPI.Model\Jobbr.Server.WebAPI.Model.csproj" />
+    <ProjectReference Include="..\WebAPI.Model\Jobbr.Server.WebAPI.Model.csproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\icon.png" Pack="true" PackagePath="images/" />

--- a/src/WebAPI/version.json
+++ b/src/WebAPI/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.6",
+  "version": "3.0.7",
   "pathFilters": ["."],
   "inherit": true
 }


### PR DESCRIPTION
This ensures that the generated nuspec file doesn't create a dependency on the WebApi.Model as package which doesn't exist

Additional step to ca4ed3184625f1453ba15540fd0652135ec8aeff