### PR TITLE
Mark Jobbr.Runtime as private reference

### DIFF
--- a/samples/Sample.JobRunner/Sample.JobRunner.csproj
+++ b/samples/Sample.JobRunner/Sample.JobRunner.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Execution\Forked\Runtime\Jobbr.Runtime.ForkedExecution.csproj" />
+    <ProjectReference Include="..\..\src\Runtime\Jobbr.Runtime.csproj" />
     <ProjectReference Include="..\Sample.Jobbr.Server\Sample.Jobbr.Server.csproj" />
   </ItemGroup>
   <ImportGroup>

--- a/samples/Sandbox.JobRunner/Sandbox.JobRunner.csproj
+++ b/samples/Sandbox.JobRunner/Sandbox.JobRunner.csproj
@@ -10,5 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Execution\Forked\Runtime\Jobbr.Runtime.ForkedExecution.csproj" />
+    <ProjectReference Include="..\..\src\Runtime\Jobbr.Runtime.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Execution/Forked/Runtime/Jobbr.Runtime.ForkedExecution.csproj
+++ b/src/Execution/Forked/Runtime/Jobbr.Runtime.ForkedExecution.csproj
@@ -12,7 +12,9 @@
     <PackageIcon>images\icon.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Runtime\Jobbr.Runtime.csproj" />
+    <ProjectReference Include="..\..\..\Runtime\Jobbr.Runtime.csproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="[2.9.1,)" />
@@ -26,6 +28,8 @@
   <ItemGroup>
     <None Include="..\..\..\icon.png" Pack="true" PackagePath="images/" />
     <None Include="..\README.md" Pack="true" PackagePath="/" />
+    <BuildOutputInPackage Include="$(OutputPath)Jobbr.Runtime.dll" />
+    <BuildOutputInPackage Include="$(OutputPath)Jobbr.Runtime.pdb" />
   </ItemGroup>
   <ImportGroup>
     <Import Project="..\..\..\DevSupport\StyleCopAnalyzer\Jobbr.DevSupport.StyleCopAnalyzer.targets" />

--- a/src/Execution/Forked/Server/version.json
+++ b/src/Execution/Forked/Server/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.3",
+  "version": "3.0.4",
   "pathFilters": ["."],
   "inherit": true
 }


### PR DESCRIPTION
This prevents the nuspec generation from referencing the runtime as external NuGet package

See also #59