### PR TITLE
Fix trigger parameter conversion and start/end date resetting

### DIFF
--- a/src/WebAPI.Tests/ClientTests.cs
+++ b/src/WebAPI.Tests/ClientTests.cs
@@ -105,7 +105,8 @@ namespace Jobbr.WebAPI.Tests
 
                 var trigger = new RecurringTrigger
                 {
-                    Definition = "* * * * *"
+                    Definition = "* * * * *",
+                    Parameters = "{\"Param1\":\"abc\",\"Param2\":123}"
                 };
                 JobStorage.AddTrigger(job.Id, trigger);
 
@@ -114,6 +115,7 @@ namespace Jobbr.WebAPI.Tests
                 Assert.IsNotNull(triggerDto);
                 Assert.AreEqual(trigger.Id, triggerDto.Id);
                 Assert.AreEqual(trigger.Definition, triggerDto.Definition);
+                Assert.AreEqual(trigger.Parameters, triggerDto.Parameters.ToString());
             }
         }
 
@@ -363,12 +365,13 @@ namespace Jobbr.WebAPI.Tests
 
                 var trigger = new RecurringTrigger
                 {
-                    Definition = definition
+                    Definition = definition,
+                    EndDateTimeUtc = DateTime.UtcNow.AddDays(10)
                 };
 
                 JobStorage.AddTrigger(job.Id, trigger);
 
-                var triggerDto = client.UpdateTrigger(job.Id, new RecurringTriggerDto { Id = trigger.Id, IsActive = true });
+                var triggerDto = client.UpdateTrigger(job.Id, new RecurringTriggerDto { Id = trigger.Id, IsActive = true, EndDateTimeUtc = null });
 
                 Assert.IsNotNull(triggerDto);
                 Assert.IsTrue(triggerDto.IsActive);
@@ -377,7 +380,8 @@ namespace Jobbr.WebAPI.Tests
 
                 Assert.IsTrue(trigger2.IsActive);
                 Assert.IsNotNull(trigger2.Definition);
-                Assert.IsTrue(trigger2.Definition == definition);
+                Assert.AreEqual(definition, trigger2.Definition);
+                Assert.IsNull(trigger2.EndDateTimeUtc);
             }
         }
 

--- a/src/WebAPI/Controller/Mapping/TriggerMapper.cs
+++ b/src/WebAPI/Controller/Mapping/TriggerMapper.cs
@@ -104,7 +104,7 @@ namespace Jobbr.Server.WebAPI.Controller.Mapping
             dto.Id = trigger.Id;
             dto.Comment = trigger.Comment;
             dto.IsActive = trigger.IsActive;
-            dto.Parameters = trigger.Parameters != null ? JsonSerializer.Deserialize<JobTriggerDtoBase>(trigger.Parameters, DefaultJsonOptions.Options) : null;
+            dto.Parameters = trigger.Parameters != null ? JsonSerializer.Deserialize<object>(trigger.Parameters, DefaultJsonOptions.Options) : null;
             dto.UserDisplayName = trigger.UserDisplayName;
             dto.UserId = trigger.UserId;
             dto.Deleted = trigger.Deleted;
@@ -122,7 +122,7 @@ namespace Jobbr.Server.WebAPI.Controller.Mapping
         {
             trigger.Comment = dto.Comment;
             trigger.IsActive = dto.IsActive;
-            trigger.Parameters = trigger.Parameters is null ? null : JsonSerializer.Serialize(dto.Parameters, DefaultJsonOptions.Options);
+            trigger.Parameters = dto.Parameters is null ? null : JsonSerializer.Serialize(dto.Parameters, DefaultJsonOptions.Options);
             trigger.UserDisplayName = dto.UserDisplayName;
             trigger.UserId = dto.UserId;
             trigger.Deleted = dto.Deleted;

--- a/src/WebAPI/Controller/TriggerController.cs
+++ b/src/WebAPI/Controller/TriggerController.cs
@@ -80,8 +80,8 @@ namespace Jobbr.Server.WebAPI.Controller
                 trigger.Id = triggerId;
                 trigger.JobId = jobId;
                 trigger.Definition = recurringTriggerDto.Definition ?? existingTrigger.Definition;
-                trigger.StartDateTimeUtc = recurringTriggerDto.StartDateTimeUtc ?? existingTrigger.StartDateTimeUtc;
-                trigger.EndDateTimeUtc = recurringTriggerDto.EndDateTimeUtc ?? existingTrigger.EndDateTimeUtc;
+                trigger.StartDateTimeUtc = recurringTriggerDto.StartDateTimeUtc;
+                trigger.EndDateTimeUtc = recurringTriggerDto.EndDateTimeUtc;
 
                 _jobManagementService.Update(trigger);
             }

--- a/src/WebAPI/version.json
+++ b/src/WebAPI/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.0",
+  "version": "3.1.1",
   "pathFilters": ["."],
   "inherit": true
 }


### PR DESCRIPTION
- The API returned the wrong DTO for triggers
- The API prevented the resetting of Start/EndDateTimeUtc on Recurring triggers