### PR TITLE
Switch to trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   GITHUBACTIONS: "True"
 
@@ -14,6 +16,8 @@ jobs:
   build:
     name: ${{ matrix.platform.name }} ${{ matrix.dotnet.name }}
     runs-on: ${{ matrix.platform.os }}
+    permissions:
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -78,9 +82,16 @@ jobs:
           name: jobbr-${{ matrix.platform.os }}-${{ matrix.dotnet.version }}
           path: publish/*nupkg
 
+      - name: NuGet Login
+        if: github.ref == 'refs/heads/master' && matrix.dotnet.name == '.NET 8' && runner.os == 'Windows'
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: jobbr
+
       - name: Publish Jobbr NuGet Packages
         if: github.ref == 'refs/heads/master' && matrix.dotnet.name == '.NET 8' && runner.os == 'Windows'
         run: |
           foreach($file in (Get-ChildItem publish -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+              dotnet nuget push $file --api-key "${{steps.login.outputs.NUGET_API_KEY}}" --source https://api.nuget.org/v3/index.json --skip-duplicate
           }


### PR DESCRIPTION
API Keys are not recommended anymore and trusted publishing provides an additional layer of security, as API keys are short lived and can't be "leaked" in the same sense.